### PR TITLE
Fix board initialization row count

### DIFF
--- a/src/context/GlobalStore.tsx
+++ b/src/context/GlobalStore.tsx
@@ -14,13 +14,13 @@ export const useGlobalStore = () => {
 }
 
 const createInitialBoardState = () => {
-	const boardState: GlobalStoreState['boardState'] = {}
-	for (let row = 1; row <= 5; row++) {
-		for (let col = 1; col <= 5; col++) {
-			boardState[`${row}-${col}`] = { value: '', state: '' }
-		}
-	}
-	return boardState
+        const boardState: GlobalStoreState['boardState'] = {}
+        for (let row = 1; row <= 6; row++) {
+                for (let col = 1; col <= 5; col++) {
+                        boardState[`${row}-${col}`] = { value: '', state: '' }
+                }
+        }
+        return boardState
 }
 
 export const GlobalStoreProvider: FC<{ children: React.ReactNode }> = ({


### PR DESCRIPTION
## Summary
- ensure `createInitialBoardState` builds the full 6-row board

## Testing
- `yarn build` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6849912339e88330ac27c3c78b8def8e